### PR TITLE
Update config.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,5 @@
 blank_issues_enabled: false
+contact_links:
+  - name: Third Party (non-AWS) Resource Requests
+    url: https://github.com/aws-cloudformation/community-registry-extensions
+    about: Third-party CloudFormation resource requests can be submitted in our Community Registry Extensions repo.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,3 +3,4 @@ contact_links:
   - name: Third Party (non-AWS) Resource Requests
     url: https://github.com/aws-cloudformation/community-registry-extensions
     about: Third-party CloudFormation resource requests can be submitted in our Community Registry Extensions repo.
+


### PR DESCRIPTION
Adding new issue option to redirect to Community Registry Extensions repo for submitting and tracking 3rd party resource coverage

*Issue #, if available:* N/A

*Description of changes:* We are using the CloudFormation Community Registry Extension for 3rd party resource coverage requests. We would like to add a new issue type to the public coverage roadmap repo to redirect users looking to submit requests for 3rd parties to the other repo.

![image](https://user-images.githubusercontent.com/118005641/218137093-b8221631-4a99-49cb-b0a2-204b2e826c12.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
